### PR TITLE
DT-1059: updated delete case note endpoint to accept a string …

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/casenotes/controllers/CaseNoteController.java
+++ b/src/main/java/uk/gov/justice/hmpps/casenotes/controllers/CaseNoteController.java
@@ -40,7 +40,6 @@ import uk.gov.justice.hmpps.casenotes.services.CaseNoteService;
 import javax.validation.constraints.NotNull;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
@@ -212,7 +211,7 @@ public class CaseNoteController {
             @ApiResponse(code = 404, message = "Offender or case note not found")})
     public void softDeleteCaseNote(
             @ApiParam(value = "Offender Identifier", required = true, example = "A1234AA") @PathVariable("offenderIdentifier") final String offenderIdentifier,
-            @ApiParam(value = "Case Note Id", required = true, example = "518b2200-6489-4c77-8514-10cf80ccd488") @PathVariable("caseNoteId") final UUID caseNoteId) {
+            @ApiParam(value = "Case Note Id", required = true, example = "518b2200-6489-4c77-8514-10cf80ccd488") @PathVariable("caseNoteId") final String caseNoteId) {
         caseNoteService.softDeleteCaseNote(offenderIdentifier, caseNoteId);
     }
 

--- a/src/test/java/uk/gov/justice/hmpps/casenotes/controllers/CaseNoteResourceTest.kt
+++ b/src/test/java/uk/gov/justice/hmpps/casenotes/controllers/CaseNoteResourceTest.kt
@@ -471,6 +471,22 @@ class CaseNoteResourceTest : ResourceTest() {
   }
 
   @Test
+  fun testDeleteNOMISCaseNoteNotFound() {
+    oAuthApi.subGetUserDetails("DELETE_CASE_NOTE_USER")
+    val token = jwtHelper.createJwt("DELETE_CASE_NOTE_USER", roles = DELETE_CASENOTE_ROLES)
+
+    webTestClient.delete().uri("/case-notes/{offenderIdentifier}/{caseNoteId}", "Z1234ZZ", "12345678")
+        .headers(addBearerToken(token))
+        .exchange()
+        .expectStatus().isBadRequest
+        .expectBody()
+        .json("{" +
+            "'status':400," +
+            "'developerMessage':'Case note id not a sensitive case note, please delete through NOMIS'" +
+            "}")
+  }
+
+  @Test
   fun testSoftDeleteCaseNoteNotFound() {
     oAuthApi.subGetUserDetails("DELETE_CASE_NOTE_USER")
     val token = jwtHelper.createJwt("DELETE_CASE_NOTE_USER", roles = DELETE_CASENOTE_ROLES)
@@ -484,7 +500,6 @@ class CaseNoteResourceTest : ResourceTest() {
             "'status':404," +
             "'developerMessage':'Case note not found'" +
             "}")
-
   }
 
   @Test

--- a/src/test/java/uk/gov/justice/hmpps/casenotes/services/CaseNoteServiceTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/casenotes/services/CaseNoteServiceTest.java
@@ -233,7 +233,7 @@ public class CaseNoteServiceTest {
         when(repository.findById(any())).thenReturn(Optional.of(offenderCaseNote));
         when(securityUserContext.getCurrentUser()).thenReturn(new UserIdUser("user", "userId"));
 
-        caseNoteService.softDeleteCaseNote("A1234AC", offenderCaseNoteId);
+        caseNoteService.softDeleteCaseNote("A1234AC", offenderCaseNoteId.toString());
 
         verify(repository).deleteById(offenderCaseNoteId);
     }
@@ -246,7 +246,7 @@ public class CaseNoteServiceTest {
         when(repository.findById(any())).thenReturn(Optional.of(offenderCaseNote));
         when(securityUserContext.getCurrentUser()).thenReturn(new UserIdUser("user", "userId"));
 
-        caseNoteService.softDeleteCaseNote("A1234AC", offenderCaseNoteId);
+        caseNoteService.softDeleteCaseNote("A1234AC", offenderCaseNoteId.toString());
 
         verify(telemetryClient).trackEvent("SecureCaseNoteSoftDelete", Map.of("userName", "user", "offenderId", "A1234AC", "case note id", offenderCaseNoteId.toString()), null);
     }
@@ -254,7 +254,7 @@ public class CaseNoteServiceTest {
     @Test
     public void softDeleteCaseNoteEntityNotFoundExceptionThrownWhenCaseNoteNotFound() {
 
-        assertThatThrownBy(() -> caseNoteService.softDeleteCaseNote("A1234AC", UUID.randomUUID())).isInstanceOf(EntityNotFoundException.class);
+        assertThatThrownBy(() -> caseNoteService.softDeleteCaseNote("A1234AC", UUID.randomUUID().toString())).isInstanceOf(EntityNotFoundException.class);
 
     }
 
@@ -265,7 +265,7 @@ public class CaseNoteServiceTest {
         final var offenderCaseNoteId = offenderCaseNote.getId();
         when(repository.findById(any())).thenReturn(Optional.of(offenderCaseNote));
 
-        assertThatThrownBy(() -> caseNoteService.softDeleteCaseNote("Z9999ZZ", offenderCaseNoteId)).isInstanceOf(ValidationException.class);
+        assertThatThrownBy(() -> caseNoteService.softDeleteCaseNote("Z9999ZZ", offenderCaseNoteId.toString())).isInstanceOf(ValidationException.class);
     }
 
     @Test


### PR DESCRIPTION
…instead of UUID and the return error if not a sensitive case note id, so that the endpoint signature is the same as the get request