### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/helm_deploy/offender-case-notes/Chart.yaml
+++ b/helm_deploy/offender-case-notes/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.1.1
 
 dependencies:
   - name: generic-service
-    version: 2.7
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3

--- a/helm_deploy/offender-case-notes/values.yaml
+++ b/helm_deploy/offender-case-notes/values.yaml
@@ -1,4 +1,3 @@
----
 # Values here are the same across all environments
 generic-service:
   nameOverride: offender-case-notes
@@ -6,7 +5,7 @@ generic-service:
 
   image:
     repository: quay.io/hmpps/offender-case-notes
-    tag: app_version    # override at deployment time
+    tag: app_version # override at deployment time
     port: 8080
 
   ingress:
@@ -54,14 +53,8 @@ generic-service:
       HMPPS_SQS_QUEUES_EVENT_DLQ_NAME: "sqs_ocne_name"
 
   allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    mojvpn: "81.134.202.29/32"
-    petty-france-wifi: "213.121.161.112/28"
-    global-protect: "35.176.93.186/32"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
+    groups:
+      - internal
 
 generic-prometheus-alerts:
   targetApplication: offender-case-notes

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -1,4 +1,3 @@
----
 # Environment specific values, override helm_deploy/prison-to-probation-update/values.yaml
 generic-service:
   replicaCount: 2
@@ -15,12 +14,13 @@ generic-service:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
 
   allowlist:
-    delius-dev-1: "35.178.19.203/32"
-    delius-dev-2: "35.177.67.41/32"
-    delius-dev-3: "35.178.40.151/32"
-    delius-test-1: "35.176.126.163/32"
-    delius-test-2: "35.178.162.73/32"
-    delius-test-3: "52.56.195.113/32"
+    delius-dev-1: 35.178.19.203/32
+    delius-dev-2: 35.177.67.41/32
+    delius-dev-3: 35.178.40.151/32
+    delius-test-1: 35.176.126.163/32
+    delius-test-2: 35.178.162.73/32
+    delius-test-3: 52.56.195.113/32
+    groups: []
 
 # CloudPlatform AlertManager receiver to route promethues alerts to slack
 generic-prometheus-alerts:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -1,4 +1,3 @@
----
 # Environment specific values, override helm_deploy/prison-to-probation-update/values.yaml
 generic-service:
   replicaCount: 2
@@ -15,9 +14,10 @@ generic-service:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
 
   allowlist:
-    delius-pre-prod-1: "52.56.240.62/32"
-    delius-pre-prod-2: "18.130.110.168/32"
-    delius-pre-prod-3: "35.178.44.184/32"
+    delius-pre-prod-1: 52.56.240.62/32
+    delius-pre-prod-2: 18.130.110.168/32
+    delius-pre-prod-3: 35.178.44.184/32
+    groups: []
 
 # CloudPlatform AlertManager receiver to route promethues alerts to slack
 generic-prometheus-alerts:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -1,4 +1,3 @@
----
 # Environment specific values, override helm_deploy/prison-to-probation-update/values.yaml
 generic-service:
   replicaCount: 4
@@ -30,9 +29,10 @@ generic-service:
         DB_HOST_PREPROD: "rds_instance_address"
 
   allowlist:
-    delius-prod-1: "52.56.115.146/32"
-    delius-prod-2: "35.178.104.253/32"
-    delius-prod-3: "35.177.47.45/32"
+    delius-prod-1: 52.56.115.146/32
+    delius-prod-2: 35.178.104.253/32
+    delius-prod-3: 35.177.47.45/32
+    groups: []
 
 # CloudPlatform AlertManager receiver to route promethues alerts to slack
 generic-prometheus-alerts:


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

4 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/offender-case-notes/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal`
- The size of the allowlist defined in this file will change: `8 => 0 (8 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick
  

## Allowlist: helm_deploy/values-dev.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: ``
- The size of the allowlist defined in this file will change: `6 => 6 (0 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:

  **No IPs have been identified for removal**
  

## Allowlist: helm_deploy/values-preprod.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: ``
- The size of the allowlist defined in this file will change: `3 => 3 (0 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:

  **No IPs have been identified for removal**
  

## Allowlist: helm_deploy/values-prod.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: ``
- The size of the allowlist defined in this file will change: `3 => 3 (0 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:

  **No IPs have been identified for removal**
  
