### PR TITLE
CDPS-735: Get authorUserId from UserDetails

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/casenotes/dto/UserDetails.kt
+++ b/src/main/java/uk/gov/justice/hmpps/casenotes/dto/UserDetails.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.hmpps.casenotes.dto
+
+class UserDetails(
+  val username: String? = null,
+  val active: Boolean? = null,
+  val name: String? = null,
+  val authSource: String? = null,
+  val staffId: Number? = null,
+  val activeCaseLoadId: String? = null,
+  val userId: String? = null,
+  val uuid: String? = null,
+)

--- a/src/main/java/uk/gov/justice/hmpps/casenotes/services/ExternalApiService.kt
+++ b/src/main/java/uk/gov/justice/hmpps/casenotes/services/ExternalApiService.kt
@@ -14,7 +14,9 @@ import uk.gov.justice.hmpps.casenotes.dto.NewCaseNote
 import uk.gov.justice.hmpps.casenotes.dto.NomisCaseNote
 import uk.gov.justice.hmpps.casenotes.dto.OffenderBooking
 import uk.gov.justice.hmpps.casenotes.dto.UpdateCaseNote
+import uk.gov.justice.hmpps.casenotes.dto.UserDetails
 import java.time.format.DateTimeFormatter
+import java.util.Optional
 
 @Service
 class ExternalApiService(
@@ -49,14 +51,11 @@ class ExternalApiService(
       .bodyToMono(OffenderBooking::class.java)
       .block()!!
 
-  fun getUserFullName(currentUsername: String): String =
+  fun getUserDetails(currentUsername: String): Optional<UserDetails> =
     oauthApiWebClient.get().uri("/api/user/{username}", currentUsername)
       .retrieve()
-      .bodyToMono(
-        object : ParameterizedTypeReference<Map<String, String>>() {},
-      )
-      .blockOptional().map { u -> u["name"] ?: currentUsername }
-      .orElse(currentUsername)
+      .bodyToMono(UserDetails::class.java)
+      .blockOptional()
 
   fun getOffenderLocation(offenderIdentifier: String): String =
     elite2ApiWebClient.get().uri("/api/bookings/offenderNo/{offenderNo}", offenderIdentifier)

--- a/src/test/java/uk/gov/justice/hmpps/casenotes/services/ExternalApiServiceTest.kt
+++ b/src/test/java/uk/gov/justice/hmpps/casenotes/services/ExternalApiServiceTest.kt
@@ -35,7 +35,9 @@ import uk.gov.justice.hmpps.casenotes.dto.NewCaseNote
 import uk.gov.justice.hmpps.casenotes.dto.NomisCaseNote
 import uk.gov.justice.hmpps.casenotes.dto.OffenderBooking
 import uk.gov.justice.hmpps.casenotes.dto.UpdateCaseNote
+import uk.gov.justice.hmpps.casenotes.dto.UserDetails
 import java.time.LocalDateTime
+import java.util.Optional
 
 class ExternalApiServiceTest {
   private val responseSpecMock: ResponseSpec = mock()
@@ -129,35 +131,21 @@ class ExternalApiServiceTest {
   }
 
   @Nested
-  inner class getUserFullName {
+  inner class getUserDetails {
     @Test
     fun `test calls HMPPS Auth`() {
-      whenever(responseSpecMock.bodyToMono(any<ParameterizedTypeReference<*>>())).thenReturn(
-        Mono.just(mapOf("name" to "Joe")),
-      )
-      assertThat(externalApiService.getUserFullName("user")).isEqualTo("Joe")
+      val userDetails = UserDetails(name = "Joe")
+      whenever(responseSpecMock.bodyToMono(any<Class<*>>())).thenReturn(Mono.just(userDetails))
+      assertThat(externalApiService.getUserDetails("user")).isEqualTo(Optional.of(userDetails))
 
       verify(authWebClient).get()
       verify(requestHeadersUriSpec).uri("/api/user/{username}", "user")
     }
 
     @Test
-    fun `test calls HMPPS Auth and returns default value`() {
-      whenever(responseSpecMock.bodyToMono(any<ParameterizedTypeReference<*>>())).thenReturn(
-        Mono.just(emptyMap<String, String>()),
-      )
-      assertThat(externalApiService.getUserFullName("user")).isEqualTo("user")
-
-      verify(authWebClient).get()
-      verify(requestHeadersUriSpec).uri("/api/user/{username}", "user")
-    }
-
-    @Test
-    fun `test calls HMPPS Auth and returns default value if no response`() {
-      whenever(responseSpecMock.bodyToMono(any<ParameterizedTypeReference<*>>())).thenReturn(
-        Mono.empty(),
-      )
-      assertThat(externalApiService.getUserFullName("user")).isEqualTo("user")
+    fun `test calls HMPPS Auth and returns empty if no response`() {
+      whenever(responseSpecMock.bodyToMono(any<Class<*>>())).thenReturn(Mono.empty())
+      assertThat(externalApiService.getUserDetails("user")).isEmpty
 
       verify(authWebClient).get()
       verify(requestHeadersUriSpec).uri("/api/user/{username}", "user")

--- a/src/test/resources/uk/gov/justice/hmpps/casenotes/controllers/A1234AA-casenote.json
+++ b/src/test/resources/uk/gov/justice/hmpps/casenotes/controllers/A1234AA-casenote.json
@@ -6,7 +6,7 @@
       "typeDescription": "POM Notes",
       "subType": "GEN",
       "subTypeDescription": "General POM Note",
-      "authorUserId": "SECURE_CASENOTE_USER_ID",
+      "authorUserId": "1111",
       "authorName": "Mikey Mouse",
       "text": "This is a case note",
       "locationId": "LEI",

--- a/src/test/resources/uk/gov/justice/hmpps/casenotes/controllers/A1234AA-create-casenote.json
+++ b/src/test/resources/uk/gov/justice/hmpps/casenotes/controllers/A1234AA-create-casenote.json
@@ -4,7 +4,7 @@
   "typeDescription": "POM Notes",
   "subType": "GEN",
   "subTypeDescription": "General POM Note",
-  "authorUserId": "SECURE_CASENOTE_USER_ID",
+  "authorUserId": "1111",
   "authorName": "Mikey Mouse",
   "text": "This is a case note",
   "amendments": []

--- a/src/test/resources/uk/gov/justice/hmpps/casenotes/controllers/A1234AB-casenote.json
+++ b/src/test/resources/uk/gov/justice/hmpps/casenotes/controllers/A1234AB-casenote.json
@@ -6,14 +6,14 @@
       "typeDescription": "POM Notes",
       "subType": "GEN",
       "subTypeDescription": "General POM Note",
-      "authorUserId": "SECURE_CASENOTE_USER_ID",
+      "authorUserId": "1111",
       "authorName": "Mikey Mouse",
       "text": "This is another case note",
       "locationId": "LEI",
       "amendments": [
         {
           "authorUserName": "SECURE_CASENOTE_USER",
-          "authorUserId": "SECURE_CASENOTE_USER_ID",
+          "authorUserId": "1111",
           "additionalNoteText": "Amended case note"
         }
       ]

--- a/src/test/resources/uk/gov/justice/hmpps/casenotes/controllers/A1234AB-update-casenote.json
+++ b/src/test/resources/uk/gov/justice/hmpps/casenotes/controllers/A1234AB-update-casenote.json
@@ -4,14 +4,14 @@
   "typeDescription": "POM Notes",
   "subType": "GEN",
   "subTypeDescription": "General POM Note",
-  "authorUserId": "SECURE_CASENOTE_USER_ID",
+  "authorUserId": "1111",
   "authorName": "Mikey Mouse",
   "text": "This is another case note",
   "locationId": "LEI",
   "amendments": [
     {
       "authorUserName": "SECURE_CASENOTE_USER",
-      "authorUserId": "SECURE_CASENOTE_USER_ID",
+      "authorUserId": "1111",
       "additionalNoteText": "Amended case note"
     }
   ]

--- a/src/test/resources/uk/gov/justice/hmpps/casenotes/controllers/A1234AC-casenote.json
+++ b/src/test/resources/uk/gov/justice/hmpps/casenotes/controllers/A1234AC-casenote.json
@@ -7,7 +7,7 @@
       "subType": "GEN",
       "subTypeDescription": "General POM Note",
       "source": "OCNS",
-      "authorUserId": "SECURE_CASENOTE_USER_ID",
+      "authorUserId": "1111",
       "authorName": "Mikey Mouse",
       "text": "This is a case note 1",
       "locationId": "MDI",

--- a/src/test/resources/uk/gov/justice/hmpps/casenotes/controllers/A1234AD-create-casenote.json
+++ b/src/test/resources/uk/gov/justice/hmpps/casenotes/controllers/A1234AD-create-casenote.json
@@ -4,7 +4,7 @@
   "typeDescription": "POM Notes",
   "subType": "GEN",
   "subTypeDescription": "General POM Note",
-  "authorUserId": "SECURE_CASENOTE_USER_ID",
+  "authorUserId": "1111",
   "authorName": "Mikey Mouse",
   "text": "This is another case note",
   "locationId": "LEI",

--- a/src/test/resources/uk/gov/justice/hmpps/casenotes/controllers/A1234AF-single-casenote.json
+++ b/src/test/resources/uk/gov/justice/hmpps/casenotes/controllers/A1234AF-single-casenote.json
@@ -4,7 +4,7 @@
   "typeDescription": "POM Notes",
   "subType": "GEN",
   "subTypeDescription": "General POM Note",
-  "authorUserId": "SECURE_CASENOTE_USER_ID",
+  "authorUserId": "1111",
   "authorName": "Mikey Mouse",
   "text": "This is a case note",
   "locationId": "LEI",

--- a/src/test/resources/uk/gov/justice/hmpps/casenotes/controllers/A1234BA-single-casenote.json
+++ b/src/test/resources/uk/gov/justice/hmpps/casenotes/controllers/A1234BA-single-casenote.json
@@ -4,7 +4,7 @@
   "typeDescription": "POM Notes",
   "subType": "GEN",
   "subTypeDescription": "General POM Note",
-  "authorUserId": "DELETE_CASE_NOTE_USER_ID",
+  "authorUserId": "1111",
   "authorName": "Mikey Mouse",
   "text": "This is a case note",
   "locationId": "LEI",

--- a/src/test/resources/uk/gov/justice/hmpps/casenotes/controllers/A1234BC-deleted-amendment-casenote.json
+++ b/src/test/resources/uk/gov/justice/hmpps/casenotes/controllers/A1234BC-deleted-amendment-casenote.json
@@ -4,7 +4,7 @@
   "typeDescription": "POM Notes",
   "subType": "GEN",
   "subTypeDescription": "General POM Note",
-  "authorUserId": "DELETE_CASE_NOTE_USER_ID",
+  "authorUserId": "1111",
   "authorName": "Mikey Mouse",
   "text": "This is a case note",
   "locationId": "LEI",

--- a/src/test/resources/uk/gov/justice/hmpps/casenotes/controllers/A1234BC-update-casenote.json
+++ b/src/test/resources/uk/gov/justice/hmpps/casenotes/controllers/A1234BC-update-casenote.json
@@ -4,14 +4,14 @@
   "typeDescription": "POM Notes",
   "subType": "GEN",
   "subTypeDescription": "General POM Note",
-  "authorUserId": "DELETE_CASE_NOTE_USER_ID",
+  "authorUserId": "1111",
   "authorName": "Mikey Mouse",
   "text": "This is a case note",
   "locationId": "LEI",
   "amendments": [
     {
       "authorUserName": "DELETE_CASE_NOTE_USER",
-      "authorUserId": "DELETE_CASE_NOTE_USER_ID",
+      "authorUserId": "1111",
       "additionalNoteText": "Amended case note"
     }
   ]


### PR DESCRIPTION
In https://dsdmoj.atlassian.net/browse/CDPS-686, we allowed client credentials clients to decide whether they want to exclude sensitive case notes from being retrieved.  This was to prevent having to introduce a dependency on the Restricted Patients API for Offender Case Notes API to correctly provide access to Restricted Patients case notes, on an already struggling service.



In using the client credentials token, we lose the staff_id attribute from the token so the authorStaffId defaults to username currently.  This work is to return to use the staff_id attribute taken from the UserDetails data already retrieved from HMPPS Auth.

I was a little unsure as to whether this follow up ticket was necessary since any client should be prepared for that field to be either a staff id OR a username (this default behaviour is not really ideal, it means that the data is very messy).  I thought it would be worth returning to what it was previously doing in case there are clients out there that are not aware that this field can potentially be multiple types.