### PR TITLE
MICN-158 add Author object to Migrate/SyncCaseNoteRequest

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/casenotes/sync/MigrateCaseNoteRequest.kt
+++ b/src/main/java/uk/gov/justice/hmpps/casenotes/sync/MigrateCaseNoteRequest.kt
@@ -12,9 +12,7 @@ data class MigrateCaseNoteRequest(
   override val occurrenceDateTime: LocalDateTime,
   override val text: String,
   override val systemGenerated: Boolean,
-  override val authorUsername: String,
-  override val authorUserId: String,
-  override val authorName: String,
+  override val author: CreateAuthor,
   override val createdDateTime: LocalDateTime,
   override val createdByUsername: String,
   override val source: Source,
@@ -23,8 +21,6 @@ data class MigrateCaseNoteRequest(
 
 data class MigrateAmendmentRequest(
   override val text: String,
-  override val authorUsername: String,
-  override val authorUserId: String,
-  override val authorName: String,
+  override val author: AmendAuthor,
   override val createdDateTime: LocalDateTime,
 ) : SyncAmendmentRequest

--- a/src/main/java/uk/gov/justice/hmpps/casenotes/sync/SyncCaseNoteRequest.kt
+++ b/src/main/java/uk/gov/justice/hmpps/casenotes/sync/SyncCaseNoteRequest.kt
@@ -21,9 +21,7 @@ data class SyncCaseNoteRequest(
   override val occurrenceDateTime: LocalDateTime,
   override val text: String,
   override val systemGenerated: Boolean,
-  override val authorUsername: String,
-  override val authorUserId: String,
-  override val authorName: String,
+  override val author: CreateAuthor,
   override val createdDateTime: LocalDateTime,
   override val createdByUsername: String,
   override val source: Source,
@@ -32,8 +30,6 @@ data class SyncCaseNoteRequest(
 
 data class SyncCaseNoteAmendmentRequest(
   override val text: String,
-  override val authorUsername: String,
-  override val authorUserId: String,
-  override val authorName: String,
+  override val author: AmendAuthor,
   override val createdDateTime: LocalDateTime,
 ) : SyncAmendmentRequest

--- a/src/main/java/uk/gov/justice/hmpps/casenotes/sync/SyncNoteRequest.kt
+++ b/src/main/java/uk/gov/justice/hmpps/casenotes/sync/SyncNoteRequest.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.hmpps.casenotes.config.Source
 import uk.gov.justice.hmpps.casenotes.notes.AuthoredRequest
 import uk.gov.justice.hmpps.casenotes.notes.NoteRequest
 import uk.gov.justice.hmpps.casenotes.notes.TextRequest
+import uk.gov.justice.hmpps.casenotes.utils.LanguageFormatUtils
 import java.time.LocalDateTime
 
 interface SyncNoteRequest : NoteRequest, AuthoredRequest {
@@ -36,14 +37,18 @@ interface SyncNoteRequest : NoteRequest, AuthoredRequest {
   )
   override val occurrenceDateTime: LocalDateTime
 
-  @get:Schema(requiredMode = REQUIRED, description = "Username of the staff member that created the case note")
-  @get:NotBlank(message = "author username cannot be blank")
   override val authorUsername: String
+    get() = author.username
 
-  @get:Schema(requiredMode = REQUIRED, description = "Id of the staff member that created the case note")
-  @get:Length(max = 64, message = "author user id cannot be more than 64 characters")
-  @get:NotBlank(message = "author user id cannot be blank")
+  override val authorName: String
+    get() = LanguageFormatUtils.formatDisplayName("${author.firstName} ${author.lastName}").trim()
+
   val authorUserId: String
+    get() = author.userId
+
+  @get:Schema(description = "The staff member who created the case note")
+  @get:Valid
+  val author: CreateAuthor
 
   @get:Schema(
     requiredMode = REQUIRED,
@@ -73,11 +78,41 @@ interface SyncNoteRequest : NoteRequest, AuthoredRequest {
 }
 
 interface SyncAmendmentRequest : TextRequest, AuthoredRequest {
-  @get:NotBlank(message = "author username cannot be blank")
   override val authorUsername: String
-
-  @get:Length(max = 64, message = "author user id cannot be more than 64 characters")
-  @get:NotBlank(message = "author user id cannot be blank")
+    get() = author.username
+  override val authorName: String
+    get() = LanguageFormatUtils.formatDisplayName("${author.firstName} ${author.lastName}").trim()
   val authorUserId: String
+    get() = author.userId
+  @get:Schema(description = "The staff member who amended the case note")
+  @get:Valid
+  val author: AmendAuthor
   val createdDateTime: LocalDateTime
 }
+
+data class CreateAuthor(
+  @get:Schema(requiredMode = REQUIRED, description = "Full name of the staff member that created the case note")
+  @get:Length(max = 80, message = "author name cannot be more than 80 characters")
+  @get:NotBlank(message = "author name cannot be blank")
+  val username: String,
+  @get:Schema(requiredMode = REQUIRED, description = "Id of the staff member that created the case note")
+  @get:Length(max = 64, message = "author user id cannot be more than 64 characters")
+  @get:NotBlank(message = "author user id cannot be blank")
+  val userId: String,
+  @get:Schema(requiredMode = REQUIRED, description = "First name of the staff member that created the case note")
+  @get:NotBlank(message = "author first name cannot be blank")
+  val firstName: String,
+  @get:Schema(description = "Last name of the staff member that created the case note")
+  val lastName: String,
+)
+
+data class AmendAuthor(
+  @get:NotBlank(message = "author username cannot be blank")
+  val username: String,
+  @get:Length(max = 64, message = "author user id cannot be more than 64 characters")
+  @get:NotBlank(message = "author user id cannot be blank")
+  val userId: String,
+  @get:NotBlank(message = "author first name cannot be blank")
+  val firstName: String,
+  val lastName: String,
+)

--- a/src/main/java/uk/gov/justice/hmpps/casenotes/utils/LanguageFormatUtils.kt
+++ b/src/main/java/uk/gov/justice/hmpps/casenotes/utils/LanguageFormatUtils.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.hmpps.casenotes.utils
+
+object LanguageFormatUtils {
+  fun formatDisplayName(userName: String): String {
+    return userName.replace("\\s+|_".toRegex(), " ").split("(?<=[-’\\s])|(?=[-’\\s])".toRegex())
+      .joinToString("") { it.lowercase().replaceFirstChar { char -> char.uppercaseChar() } }
+  }
+}

--- a/src/test/java/uk/gov/justice/hmpps/casenotes/controllers/SyncCaseNoteIntTest.kt
+++ b/src/test/java/uk/gov/justice/hmpps/casenotes/controllers/SyncCaseNoteIntTest.kt
@@ -9,6 +9,8 @@ import uk.gov.justice.hmpps.casenotes.config.SecurityUserContext.Companion.ROLE_
 import uk.gov.justice.hmpps.casenotes.config.Source
 import uk.gov.justice.hmpps.casenotes.domain.Amendment
 import uk.gov.justice.hmpps.casenotes.domain.Note
+import uk.gov.justice.hmpps.casenotes.sync.AmendAuthor
+import uk.gov.justice.hmpps.casenotes.sync.CreateAuthor
 import uk.gov.justice.hmpps.casenotes.sync.SyncCaseNoteAmendmentRequest
 import uk.gov.justice.hmpps.casenotes.sync.SyncCaseNoteRequest
 import uk.gov.justice.hmpps.casenotes.sync.SyncResult
@@ -56,6 +58,7 @@ class SyncCaseNoteIntTest : ResourceTest() {
       assertThat(developerMessage).isEqualTo(
         """
         |400 BAD_REQUEST Validation failures: 
+        |author first name cannot be blank
         |author name cannot be blank
         |author name cannot be more than 80 characters
         |author user id cannot be blank
@@ -218,9 +221,12 @@ private fun syncCaseNoteRequest(
   occurrenceDateTime,
   text,
   systemGenerated,
-  authorUsername,
-  authorUserId,
-  authorName,
+  CreateAuthor(
+    username = authorUsername,
+    userId = authorUserId,
+    firstName = authorName.split(" ").first(),
+    lastName = authorName.split(" ").let { if (it.size > 1) it.last() else "" },
+  ),
   createdDateTime,
   createdBy,
   source,
@@ -233,7 +239,16 @@ private fun syncAmendmentRequest(
   authorUserId: String = "12376471",
   authorName: String = "Author Name",
   createdDateTime: LocalDateTime = LocalDateTime.now(),
-) = SyncCaseNoteAmendmentRequest(text, authorUsername, authorUserId, authorName, createdDateTime)
+) = SyncCaseNoteAmendmentRequest(
+  text,
+  AmendAuthor(
+    username = authorUsername,
+    userId = authorUserId,
+    firstName = authorName.split(' ').first(),
+    lastName = authorName.split(" ").let { if (it.size > 1) it.last() else "" },
+  ),
+  createdDateTime,
+)
 
 private fun Note.syncRequest() = syncCaseNoteRequest(
   legacyId = legacyId,

--- a/src/test/java/uk/gov/justice/hmpps/casenotes/utils/Verifications.kt
+++ b/src/test/java/uk/gov/justice/hmpps/casenotes/utils/Verifications.kt
@@ -34,7 +34,6 @@ fun Note.verifyAgainst(request: SyncNoteRequest) {
   assertThat(text).isEqualTo(request.text)
   assertThat(occurredAt.truncatedTo(SECONDS)).isEqualTo(request.occurrenceDateTime.truncatedTo(SECONDS))
   assertThat(createDateTime.truncatedTo(SECONDS)).isEqualTo(request.createdDateTime.truncatedTo(SECONDS))
-  assertThat(authorName).isEqualTo(request.authorName)
   assertThat(authorUsername).isEqualTo(request.authorUsername)
   assertThat(authorUserId).isEqualTo(request.authorUserId)
   assertThat(legacyId).isEqualTo(request.legacyId)


### PR DESCRIPTION
MICN-158
1. Replace authorName, authorUsername, and authorUserId with an Author object, and
2. Split authorName into firstName and lastName in the new Author object, and 
3. Convert author name to Title Case