### PR TITLE
Add schema description and examples to PageMeta

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/casenotes/notes/PagedRequest.kt
+++ b/src/main/java/uk/gov/justice/hmpps/casenotes/notes/PagedRequest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.hmpps.casenotes.notes
 
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.ValidationException
 import jakarta.validation.constraints.Min
 import org.springframework.data.domain.PageRequest
@@ -42,4 +43,11 @@ interface PagedRequest {
   fun pageable(): Pageable = PageRequest.of(page - 1, size, sort())
 }
 
-data class PageMeta(val totalElements: Int, val page: Int, val size: Int)
+data class PageMeta(
+  @Schema(description = "The total number of results across all pages", example = "1")
+  val totalElements: Int,
+  @Schema(description = "The current page number", example = "1")
+  val page: Int,
+  @Schema(description = "The maximum number of results per page", example = "10")
+  val size: Int
+)

--- a/src/main/java/uk/gov/justice/hmpps/casenotes/notes/PagedRequest.kt
+++ b/src/main/java/uk/gov/justice/hmpps/casenotes/notes/PagedRequest.kt
@@ -49,5 +49,5 @@ data class PageMeta(
   @Schema(description = "The current page number", example = "1")
   val page: Int,
   @Schema(description = "The maximum number of results per page", example = "10")
-  val size: Int
+  val size: Int,
 )


### PR DESCRIPTION
In the HMPPS Integration API we do our integration tests against mocked services using a tool called Prism. Prism reads the OpenAPI schemas and generates mocked responses based on the example data in them. 

We have some issues where the pagination data coming back with large numbers, such as in the below screenshot, causes problems in our tests.

<img width="264" alt="image" src="https://github.com/user-attachments/assets/cfbbe6b9-fb51-42d6-b134-22fac4cec672" />

This PR adds some examples to your pagination object to prevent this from happening, hopefully this is also a welcome addition from your teams point of view. Let me know if you'd like me to adjust the descriptions or add anything else, thanks!
