### PR TITLE
Updated SearchNotesRequest model schema annotations

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/casenotes/notes/SearchNotesRequest.kt
+++ b/src/main/java/uk/gov/justice/hmpps/casenotes/notes/SearchNotesRequest.kt
@@ -1,16 +1,20 @@
 package uk.gov.justice.hmpps.casenotes.notes
 
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.hmpps.casenotes.domain.Note
 import java.time.LocalDateTime
 
 data class SearchNotesRequest(
+  @Schema(required = false)
   val includeSensitive: Boolean,
+  @Schema(required = false)
   val typeSubTypes: Set<TypeSubTypeRequest> = emptySet(),
   val occurredFrom: LocalDateTime? = null,
   val occurredTo: LocalDateTime? = null,
   override val page: Int,
   override val size: Int,
+  @Schema(required = false)
   @Parameter(description = "The sort to apply to the results", example = "occurredAt,desc")
   override val sort: String = "${Note.OCCURRED_AT},desc",
 ) : PagedRequest


### PR DESCRIPTION
In the HMPPS Integration API we do our integration tests against mocked services using a tool called Prism. Prism reads the OpenAPI schemas and generates mocked responses based on the example data in them.

Prism also takes into account required fields in a request body provided by the schema, looks like the valid annotation might automatically apply required to fields, have tested against dev that the marked fields aren't required

This will allow us to not have to maintain a statically modified instance of the case-notes open-api schema - for use with our prism integration tests - with the removed marked required fields