### PR TITLE
CDPS-2041 Update webClient configuration to use hmpps-kotlin-lib template

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,10 +3,10 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "10.5.7"
-  kotlin("plugin.spring") version "2.4.0"
-  kotlin("plugin.jpa") version "2.4.0"
-  id("io.gatling.gradle") version "3.15.1"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "11.0.1"
+  kotlin("plugin.spring") version "2.4.10"
+  kotlin("plugin.jpa") version "2.4.10"
+  id("io.gatling.gradle") version "3.15.1.1"
   jacoco
 }
 
@@ -25,8 +25,8 @@ dependencies {
   runtimeOnly("org.flywaydb:flyway-database-postgresql")
   runtimeOnly("org.postgresql:postgresql")
 
-  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-autoconfigure:2.5.0")
-  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:2.5.0")
+  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-autoconfigure:3.0.0")
+  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:3.0.0")
   implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:7.4.0")
 
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
@@ -40,7 +40,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webclient")
   implementation("org.springframework.boot:spring-boot-starter-webflux")
 
-  implementation("io.sentry:sentry-spring-boot-4:8.48.0")
+  implementation("io.sentry:sentry-spring-boot-4:8.49.0")
 
   implementation("javax.activation:activation:1.1.1")
   implementation("javax.transaction:javax.transaction-api:1.3")
@@ -56,7 +56,7 @@ dependencies {
   implementation("com.google.guava:guava:33.6.0-jre")
 
   implementation(platform("com.amazonaws:aws-java-sdk-bom:1.12.797"))
-  implementation("software.amazon.awssdk:sns:2.48.0")
+  implementation("software.amazon.awssdk:sns:2.49.0")
 
   testAnnotationProcessor("org.projectlombok:lombok:1.18.46")
   testCompileOnly("org.projectlombok:lombok:1.18.46")

--- a/src/main/java/uk/gov/justice/hmpps/casenotes/config/AuthAwareTokenConverter.kt
+++ b/src/main/java/uk/gov/justice/hmpps/casenotes/config/AuthAwareTokenConverter.kt
@@ -22,5 +22,5 @@ class AuthAwareTokenConverter : Converter<Jwt, AbstractAuthenticationToken> {
 
 class AuthAwareAuthenticationToken(jwt: Jwt, userId: String, authorities: Collection<GrantedAuthority>) : JwtAuthenticationToken(jwt, authorities) {
 
-  val userIdUser: UserIdUser = UserIdUser(jwt.subject, userId)
+  val userIdUser: UserIdUser = UserIdUser(jwt.subject!!, userId)
 }

--- a/src/main/java/uk/gov/justice/hmpps/casenotes/config/WebClientConfiguration.kt
+++ b/src/main/java/uk/gov/justice/hmpps/casenotes/config/WebClientConfiguration.kt
@@ -26,6 +26,7 @@ import org.springframework.web.reactive.function.client.WebClient.Builder
 import reactor.netty.http.client.HttpClient
 import reactor.netty.http.client.HttpClient.create
 import uk.gov.justice.hmpps.casenotes.utils.UserContext
+import uk.gov.justice.hmpps.kotlin.auth.ServletRequestResponseNonNullFilterFunction
 import uk.gov.justice.hmpps.kotlin.auth.service.GlobalPrincipalOAuth2AuthorizedClientService
 import java.time.Duration
 import java.time.Duration.ofSeconds
@@ -93,8 +94,8 @@ class WebClientConfiguration(
 
   @Bean
   fun authorizedClientManagerAppScope(
-    clientRegistrationRepository: ClientRegistrationRepository?,
-    @Qualifier("globalOAuth2AuthorizedClientService") clientService: GlobalPrincipalOAuth2AuthorizedClientService?,
+    clientRegistrationRepository: ClientRegistrationRepository,
+    @Qualifier("globalOAuth2AuthorizedClientService") clientService: GlobalPrincipalOAuth2AuthorizedClientService,
   ): OAuth2AuthorizedClientManager {
     val authorizedClientProvider = OAuth2AuthorizedClientProviderBuilder.builder().clientCredentials().build()
     val authorizedClientManager = AuthorizedClientServiceOAuth2AuthorizedClientManager(
@@ -138,6 +139,7 @@ class WebClientConfiguration(
     oauth2Client.setDefaultClientRegistrationId("default")
     return builder.baseUrl(rootUri)
       .clientConnector(clientConnector())
+      .filter(ServletRequestResponseNonNullFilterFunction())
       .apply(oauth2Client.oauth2Configuration())
       .build()
   }

--- a/src/main/java/uk/gov/justice/hmpps/casenotes/config/WebClientConfiguration.kt
+++ b/src/main/java/uk/gov/justice/hmpps/casenotes/config/WebClientConfiguration.kt
@@ -1,35 +1,15 @@
 package uk.gov.justice.hmpps.casenotes.config
 
-import io.netty.channel.ChannelOption.CONNECT_TIMEOUT_MILLIS
-import io.netty.channel.ChannelOption.SO_KEEPALIVE
-import io.netty.channel.epoll.EpollChannelOption
-import io.netty.handler.timeout.ReadTimeoutHandler
-import io.netty.handler.timeout.WriteTimeoutHandler
 import org.hibernate.validator.constraints.URL
-import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.http.HttpHeaders
-import org.springframework.http.client.reactive.ReactorClientHttpConnector
-import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder
-import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
-import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction
-import org.springframework.web.reactive.function.client.ClientRequest
-import org.springframework.web.reactive.function.client.ExchangeFilterFunction
-import org.springframework.web.reactive.function.client.ExchangeFunction
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClient.Builder
-import reactor.netty.http.client.HttpClient
-import reactor.netty.http.client.HttpClient.create
-import uk.gov.justice.hmpps.casenotes.utils.UserContext
-import uk.gov.justice.hmpps.kotlin.auth.ServletRequestResponseNonNullFilterFunction
-import uk.gov.justice.hmpps.kotlin.auth.service.GlobalPrincipalOAuth2AuthorizedClientService
+import uk.gov.justice.hmpps.kotlin.auth.authorisedWebClient
+import uk.gov.justice.hmpps.kotlin.auth.healthWebClient
 import java.time.Duration
-import java.time.Duration.ofSeconds
 
 @Configuration
 class WebClientConfiguration(
@@ -43,131 +23,36 @@ class WebClientConfiguration(
   @param:Value($$"${api.response-timeout:2s}") private val responseTimeout: Duration,
 ) {
   @Bean
-  fun prisonApiHealthWebClient(builder: Builder): WebClient = createHealthClient(builder, prisonApiBaseUrl)
+  fun prisonApiHealthWebClient(builder: Builder): WebClient = builder.healthWebClient(prisonApiBaseUrl, healthTimeout)
 
   @Bean
-  fun oauthApiWebClient(builder: Builder): WebClient = createForwardAuthWebClient(builder, oauthApiBaseUrl)
+  fun oauthApiHealthWebClient(builder: Builder): WebClient = builder.healthWebClient(oauthApiBaseUrl, healthTimeout)
 
   @Bean
-  fun oauthApiHealthWebClient(builder: Builder): WebClient = createHealthClient(builder, oauthApiBaseUrl)
+  fun prisonerSearchApiHealthWebClient(builder: Builder): WebClient = builder.healthWebClient(prisonerSearchApiBaseUrl, healthTimeout)
 
   @Bean
-  fun prisonerSearchApiHealthWebClient(builder: Builder): WebClient = createHealthClient(builder, prisonerSearchApiBaseUrl)
+  fun manageUsersApiHealthWebClient(builder: Builder): WebClient = builder.healthWebClient(manageUsersApiBaseUrl, healthTimeout)
 
   @Bean
-  fun manageUsersApiHealthWebClient(builder: Builder): WebClient = createHealthClient(builder, manageUsersApiBaseUrl)
+  fun tokenVerificationApiHealthWebClient(builder: Builder): WebClient = builder.healthWebClient(tokenVerificationApiBaseUrl, healthTimeout)
 
   @Bean
-  fun tokenVerificationApiWebClient(builder: Builder): WebClient = builder.baseUrl(tokenVerificationApiBaseUrl)
-    .clientConnector(ReactorClientHttpConnector(create().warmupWithHealthPing(tokenVerificationApiBaseUrl))).build()
+  fun prisonApiWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: Builder): WebClient =
+    builder.authorisedWebClient(authorizedClientManager, "default", prisonApiBaseUrl, responseTimeout)
 
   @Bean
-  fun tokenVerificationApiHealthWebClient(builder: Builder): WebClient = createHealthClient(builder, tokenVerificationApiBaseUrl)
-
-  private fun createForwardAuthWebClient(builder: Builder, url: @URL String): WebClient = builder.baseUrl(url)
-    .filter(addAuthHeaderFilterFunction())
-    .clientConnector(clientConnector { it.warmupWithHealthPing(tokenVerificationApiBaseUrl) }).build()
-
-  private fun createHealthClient(builder: Builder, url: @URL String): WebClient {
-    val httpClient = create()
-      .warmupWithHealthPing(url)
-      .option(CONNECT_TIMEOUT_MILLIS, healthTimeout.toMillis().toInt())
-      .doOnConnected { connection ->
-        connection.addHandlerLast(ReadTimeoutHandler(healthTimeout.toSeconds().toInt()))
-          .addHandlerLast(WriteTimeoutHandler(healthTimeout.toSeconds().toInt()))
-      }
-    return builder.clientConnector(ReactorClientHttpConnector(httpClient)).baseUrl(url).build()
-  }
-
-  private fun addAuthHeaderFilterFunction(): ExchangeFilterFunction = ExchangeFilterFunction { request: ClientRequest, next: ExchangeFunction ->
-    val filtered = ClientRequest.from(request)
-      .header(HttpHeaders.AUTHORIZATION, UserContext.getAuthToken())
-      .build()
-    next.exchange(filtered)
-  }
+  fun prisonerSearchWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: Builder): WebClient =
+    builder.authorisedWebClient(authorizedClientManager, "default", prisonerSearchApiBaseUrl, responseTimeout)
 
   @Bean
-  @Qualifier("globalOAuth2AuthorizedClientService")
-  fun globalOAuth2AuthorizedClientService(
-    clientRegistrationRepository: ClientRegistrationRepository,
-  ) = GlobalPrincipalOAuth2AuthorizedClientService(clientRegistrationRepository)
+  fun manageUsersWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: Builder): WebClient =
+    builder.authorisedWebClient(authorizedClientManager, "default", manageUsersApiBaseUrl, responseTimeout)
 
   @Bean
-  fun authorizedClientManagerAppScope(
-    clientRegistrationRepository: ClientRegistrationRepository,
-    @Qualifier("globalOAuth2AuthorizedClientService") clientService: GlobalPrincipalOAuth2AuthorizedClientService,
-  ): OAuth2AuthorizedClientManager {
-    val authorizedClientProvider = OAuth2AuthorizedClientProviderBuilder.builder().clientCredentials().build()
-    val authorizedClientManager = AuthorizedClientServiceOAuth2AuthorizedClientManager(
-      clientRegistrationRepository,
-      clientService,
-    )
-    authorizedClientManager.setAuthorizedClientProvider(authorizedClientProvider)
-    return authorizedClientManager
-  }
+  fun alertsWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: Builder): WebClient =
+    builder.authorisedWebClient(authorizedClientManager, "default", alertsApiBaseUrl, responseTimeout)
 
   @Bean
-  fun prisonApiWebClient(
-    @Qualifier(value = "authorizedClientManagerAppScope") authorizedClientManager: OAuth2AuthorizedClientManager,
-    builder: Builder,
-  ): WebClient = getOAuthWebClient(authorizedClientManager, builder, prisonApiBaseUrl)
-
-  @Bean
-  fun prisonerSearchWebClient(
-    @Qualifier(value = "authorizedClientManagerAppScope") authorizedClientManager: OAuth2AuthorizedClientManager,
-    builder: Builder,
-  ): WebClient = getOAuthWebClient(authorizedClientManager, builder, prisonerSearchApiBaseUrl)
-
-  @Bean
-  fun manageUsersWebClient(
-    @Qualifier(value = "authorizedClientManagerAppScope") authorizedClientManager: OAuth2AuthorizedClientManager,
-    builder: Builder,
-  ): WebClient = getOAuthWebClient(authorizedClientManager, builder, manageUsersApiBaseUrl)
-
-  @Bean
-  fun alertsWebClient(
-    @Qualifier(value = "authorizedClientManagerAppScope") authorizedClientManager: OAuth2AuthorizedClientManager,
-    builder: Builder,
-  ): WebClient = getOAuthWebClient(authorizedClientManager, builder, alertsApiBaseUrl)
-
-  private fun getOAuthWebClient(
-    authorizedClientManager: OAuth2AuthorizedClientManager,
-    builder: Builder,
-    rootUri: String,
-  ): WebClient {
-    val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager)
-    oauth2Client.setDefaultClientRegistrationId("default")
-    return builder.baseUrl(rootUri)
-      .clientConnector(clientConnector())
-      .filter(ServletRequestResponseNonNullFilterFunction())
-      .apply(oauth2Client.oauth2Configuration())
-      .build()
-  }
-
-  private fun clientConnector(consumer: ((HttpClient) -> Unit)? = null): ReactorClientHttpConnector {
-    val client = create().responseTimeout(ofSeconds(responseTimeout.toSeconds()))
-      .option(CONNECT_TIMEOUT_MILLIS, 1000)
-      .option(SO_KEEPALIVE, true)
-      // this will show a warning on apple (arm) architecture but will work on linux x86 container
-      .option(EpollChannelOption.TCP_KEEPINTVL, 60)
-    consumer?.also { it.invoke(client) }
-    return ReactorClientHttpConnector(client)
-  }
-
-  companion object {
-    private val log = LoggerFactory.getLogger(this::class.java)
-  }
-
-  private fun HttpClient.warmupWithHealthPing(baseUrl: String): HttpClient {
-    log.info("Warming up web client for {}", baseUrl)
-    warmup().block()
-    log.info("Warming up web client for {} halfway through, now calling health ping", baseUrl)
-    try {
-      baseUrl("$baseUrl/health/ping").get().response().block(ofSeconds(30))
-    } catch (e: RuntimeException) {
-      log.error("Caught exception during warm up, carrying on regardless", e)
-    }
-    log.info("Warming up web client completed for {}", baseUrl)
-    return this
-  }
+  fun tokenVerificationApiWebClient(builder: Builder): WebClient = builder.baseUrl(tokenVerificationApiBaseUrl).build()
 }

--- a/src/main/java/uk/gov/justice/hmpps/casenotes/config/WebClientConfiguration.kt
+++ b/src/main/java/uk/gov/justice/hmpps/casenotes/config/WebClientConfiguration.kt
@@ -38,20 +38,16 @@ class WebClientConfiguration(
   fun tokenVerificationApiHealthWebClient(builder: Builder): WebClient = builder.healthWebClient(tokenVerificationApiBaseUrl, healthTimeout)
 
   @Bean
-  fun prisonApiWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: Builder): WebClient =
-    builder.authorisedWebClient(authorizedClientManager, "default", prisonApiBaseUrl, responseTimeout)
+  fun prisonApiWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: Builder): WebClient = builder.authorisedWebClient(authorizedClientManager, "default", prisonApiBaseUrl, responseTimeout)
 
   @Bean
-  fun prisonerSearchWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: Builder): WebClient =
-    builder.authorisedWebClient(authorizedClientManager, "default", prisonerSearchApiBaseUrl, responseTimeout)
+  fun prisonerSearchWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: Builder): WebClient = builder.authorisedWebClient(authorizedClientManager, "default", prisonerSearchApiBaseUrl, responseTimeout)
 
   @Bean
-  fun manageUsersWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: Builder): WebClient =
-    builder.authorisedWebClient(authorizedClientManager, "default", manageUsersApiBaseUrl, responseTimeout)
+  fun manageUsersWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: Builder): WebClient = builder.authorisedWebClient(authorizedClientManager, "default", manageUsersApiBaseUrl, responseTimeout)
 
   @Bean
-  fun alertsWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: Builder): WebClient =
-    builder.authorisedWebClient(authorizedClientManager, "default", alertsApiBaseUrl, responseTimeout)
+  fun alertsWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: Builder): WebClient = builder.authorisedWebClient(authorizedClientManager, "default", alertsApiBaseUrl, responseTimeout)
 
   @Bean
   fun tokenVerificationApiWebClient(builder: Builder): WebClient = builder.baseUrl(tokenVerificationApiBaseUrl).build()


### PR DESCRIPTION
This updates the repository to sit with the current kotlin template, which pre-rolls `WebClient` configuration for us rather than us having to hand-roll it here. This means upgrading `hmpps-gradle-spring-boot` to `11.0.0`. The resulting breaking change due to Spring 4.1.0 in `hmpps-kotlin-lib` as documented [here](https://github.com/ministryofjustice/hmpps-gradle-spring-boot/blob/main/release-notes/11.x.md#upgrade-to-spring-boot-410) is fixed through us not hand-rolling the implementation any more, and is more elegant than implementing `.filter(ServletRequestResponseNonNullFilterFunction())` before calling out to OAuth2 filters.